### PR TITLE
Fix error

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -16,7 +16,7 @@
  .navbar_container {
    display: flex;
    flex-direction: row;
-   background-color: tan;
+   background-color: rosybrown;
    height: 30px;
    justify-content: flex-end;
  }
@@ -29,3 +29,36 @@
    margin-left: 25px;
    margin-right: 25px;
  }
+ #body_of_doc {
+   display: flex;
+   flex-direction: column;
+   background-color: burlywood;
+ }
+.title_container {
+  display: flex;
+  background-color: burlywood;
+  justify-content: center;
+  flex: 1;
+  margin-top: -30px;
+}
+.intro_msg {
+  text-align: center;
+  width: 100%
+}
+.intro_msg h1 {
+  font-size: 25px;
+}
+.splash_image {
+  display: flex;
+}
+.splash_image img {
+  width: 100%;
+}
+.splash_footer {
+  display: flex;
+  background-color: burlywood;
+  justify-content: center;
+}
+.splash_footer footer {
+  text-align: center;
+}

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -23,7 +23,7 @@ class ReviewsController < ApplicationController
     params.require(:review).permit(:title, :rating, :user_name, :review_text)
   end
 
-  def book_params
-    params.require(:book_id)
-  end
+  # def book_params
+  #   params.require(:book_id)
+  # end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,9 @@
     <%= link_to "Books", books_path, class: "books_link" %>
   </nav>
   <body>
+    <section id="body_of_doc"
     <p class="flash"><%= flash.notice %></p>
     <%= yield %>
+    </section>
   </body>
 </html>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,3 +1,23 @@
 <section class="title_container">
+  <section class="intro_msg">
+    <h1>Welcome to Book Club!</h1>
+    <p>We have a variety of books for you to browse through.</p>
+    <p>You can sort our books in a variety of ways,<br/>
+      or check out the authors, the reviews, or the reviewers.</p>
+    <p>And feel free to leave your own review!</p>
+    <p>Enjoy!</p>
+  </section>
+</section>
 
+<section class="splash_image">
+  <img src="https://martijnscheijbeler.com/wp-content/uploads/2018/01/books.jpg" alt="welcome image" />
+</section>
+
+<section class="splash_footer">
+  <footer>
+    <p>This is a pair project for the Turing School of Software and Design's Backend Engineering Module 2 program.<br/>
+    The project partners are:<br/>
+    <%= link_to "Deonte Cooper", "https://github.com/djc00p" %><br/>
+    <%= link_to "Earl Stephens", "https://github.com/earl-stephens" %>
+  </footer>
 </section>

--- a/spec/features/book/index_spec.rb
+++ b/spec/features/book/index_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe "book index page", type: :feature do
       visit "/user/#{@review_6.user_name}"
 
       within "#book_title_path#{@review_6.id}"do
-      save_and_open_page
+      # save_and_open_page
         click_link "#{@book_2.title}"
       end
 

--- a/spec/features/book/show_spec.rb
+++ b/spec/features/book/show_spec.rb
@@ -1,22 +1,5 @@
 require 'rails_helper'
 
-
-describe "on the book show page" do
-  context "shows book statistics" do
-    before :each do
-      @book_1 = create(:book)
-      @book_2 = create(:book)
-    end
-  end
-end
-# As a Visitor,
-# When I visit a book's show page,
-# I see the following book information:
-# - the book title
-# - the author(s) who wrote the book
-# - the number of pages in the book
-# - the year the book was published
-# - a large image of the book cover
 RSpec.describe "book show page" do
   describe "Shows book information" do
     before :each do
@@ -25,7 +8,6 @@ RSpec.describe "book show page" do
       @book_1 = create(:book, image: "https://upload.wikimedia.org/wikipedia/en/f/f0/Harry_Potter_and_the_Half-Blood_Prince.jpg")
       create(:author_book, author: @author_1, book: @book_1)
       @author_2.books << @book_1
-
       @review_1 = create(:review, book_id: @book_1.id)
       @review_2 = create(:review, rating: 4, user_name: "John", book_id: @book_1.id)
       @review_3 = create(:review, rating: 5, user_name: "Joe", book_id: @book_1.id)
@@ -34,6 +16,7 @@ RSpec.describe "book show page" do
       @review_6 = create(:review, rating: 3, user_name: "Jane", book_id: @book_1.id)
       @review_7 = create(:review, rating: 4, user_name: "Jenny", book_id: @book_1.id)
     end
+
     it "shows book title" do
       visit book_path(@book_1)
 
@@ -94,7 +77,7 @@ RSpec.describe "book show page" do
       expect(page.all("#review")[4]).to have_content(@review_5.rating)
       expect(page.all("#review")[5]).to have_content(@review_6.rating)
       expect(page.all("#review")[6]).to have_content(@review_7.rating)
-    
+
       expect(page.all("#review")[0]).to have_content(@review_1.review_text)
       expect(page.all("#review")[1]).to have_content(@review_2.review_text)
       expect(page.all("#review")[2]).to have_content(@review_3.review_text)
@@ -104,11 +87,6 @@ RSpec.describe "book show page" do
       expect(page.all("#review")[6]).to have_content(@review_7.review_text)
     end
   end
-  # When I visit a book's show page,
-  # I see an area on the page for statistics about reviews:
-  # - the top three reviews for this book (title, rating and user only)
-  # - the bottom three reviews for this book  (title, rating and user only)
-  # - the overall average rating of all reviews for this book
 
   describe "on the book show page" do
     context "shows book statistics" do
@@ -165,30 +143,58 @@ RSpec.describe "book show page" do
           expect(page).to have_content("Average Rating: 3.1")
         end
       end
-    end
 
-    it "should let a user create a new review" do
-      visit book_path(@book_1)
+      it "should let a user create a new review" do
 
-      expect(page).to have_link("Add a new Review")
+        visit book_path(@book_1)
 
-      click_link "Add a new Review"
+        expect(page).to have_link("Add a new Review")
 
-      expect(current_path).to eq(new_book_review_path(@book_1.id))
-# save_and_open_page
-      fill_in "Title", with: "Great"
-      fill_in "Rating", with: 4
-      fill_in "User name", with: "three stooges"
-      fill_in "Review text", with: "This is a good book"
-      click_on "Create Review"
+        click_link "Add a new Review"
 
-      expect(current_path).to eq(book_path(@book_1))
+        expect(current_path).to eq(new_book_review_path(@book_1.id))
 
-      within ".book_show_info" do
-        expect(page).to have_content("Review title: Great")
-        expect(page).to have_content("Reviewer: Three Stooges")
-        expect(page).to have_content("Review rating: 4")
-        expect(page).to have_content("Review: This is a good book")
+        fill_in "Title", with: "Great"
+        fill_in "Rating", with: 4
+        fill_in "User name", with: "three stooges"
+        fill_in "Review text", with: "This is a good book"
+        click_on "Create Review"
+
+        expect(current_path).to eq(book_path(@book_1))
+
+        within ".book_show_info" do
+          expect(page).to have_content("Review title: Great")
+          expect(page).to have_content("Reviewer: Three Stooges")
+          expect(page).to have_content("Review rating: 4")
+          expect(page).to have_content("Review: This is a good book")
+        end
+      end
+
+      it "should not let a user enter partial review data" do
+
+        visit book_path(@book_1)
+
+        expect(page).to have_link("Add a new Review")
+
+        click_link "Add a new Review"
+
+        expect(current_path).to eq(new_book_review_path(@book_1.id))
+
+        #not entering a title here, so app should force an error message
+        fill_in "Rating", with: 4
+        fill_in "User name", with: "three stooges"
+        fill_in "Review text", with: "This is a good book"
+        click_on "Create Review"
+
+        expect(current_path).to eq(book_reviews_path(@book_1.id))
+        expect(page).to have_content("Incorrect data entered. Please try again.")
+
+        # within ".book_show_info" do
+        #   expect(page).to have_content("Review title: Great")
+        #   expect(page).to have_content("Reviewer: Three Stooges")
+        #   expect(page).to have_content("Review rating: 4")
+        #   expect(page).to have_content("Review: This is a good book")
+        # end
       end
     end
   end

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -1,17 +1,5 @@
 require 'rails_helper'
 
-# When I click on a user's name for any book review
-# I am taken to a show page for that user.
-# I should see all reviews that this
-# user has written.
-# Each review shows:
-# - the title of the review
-# - the description of the review
-# - the rating of the review
-# - the title of the book
-# - the thumbnail image for the book
-# - the date the review was written
-
 describe "on the user show page" do
   before :each do
     @book_1 = create(:book)
@@ -24,14 +12,10 @@ describe "on the user show page" do
   it "shows all reviews for that user" do
 
     visit book_path(@book_1)
-    # save_and_open_page
 
     within ".book_show_info" do
-      # binding.pry
       click_link "#{@review_1.user_name}"
     end
-      # save_and_open_page
-      # binding.pry
 
     expect(current_path).to eq("/user/#{@review_1.user_name}")
     expect(page).to have_content("Review Title: #{@review_1.title}")
@@ -47,4 +31,3 @@ describe "on the user show page" do
     expect(page).to_not have_content("Review Title: #{@review_3.title}")
   end
 end
-# end


### PR DESCRIPTION
RSpec was failing due to a render error when incorrect information is entered into a new review form.  Added a test to check for flash message appearing when user enters incorrect information in the new review form.  Deleted book_params from reviews controller because they are not being used.  All tests are now passing.  Coverage is 100% for both feature and model tests.